### PR TITLE
Add `--no-dupes` option for reducing clutter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,10 +145,9 @@ fn get_classes(workspace: &Node, options: &Options) -> Result<Vec<String>, Error
     if options.no_dupes {
         let mut unique = HashSet::new();
         window_classes.retain(|class| unique.insert(class.clone()));
-        Ok(unique.into_iter().collect())
-    } else {
-        Ok(window_classes)
+        window_classes.sort();
     }
+    Ok(window_classes)
 }
 
 /// Update all workspace names in tree

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@ fn get_classes(workspace: &Node, options: &Options) -> Result<Vec<String>, Error
     if options.no_dupes {
         let mut unique = HashSet::new();
         window_classes.retain(|class| unique.insert(class.clone()));
-        window_classes.sort();
     }
     Ok(window_classes)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,11 @@ fn main() -> Result<(), ExitFailure> {
                 .help("Set to no to display only icons (if available)"),
         )
         .arg(
+            Arg::with_name("no-dupes")
+                .long("no-dupes")
+                .help("Set to display each instance of a class only once"),
+        )
+        .arg(
             Arg::with_name("config")
                 .long("config")
                 .short("c")
@@ -38,6 +43,7 @@ fn main() -> Result<(), ExitFailure> {
 
     let icons = matches.value_of("icons").unwrap_or("");
     let no_names = matches.is_present("no-names");
+    let no_dupes = matches.is_present("no-dupes");
     let options = match matches.value_of("config") {
         Some(filename) => {
             let file_config = match swaywsr::config::read_toml_config(filename) {
@@ -53,6 +59,7 @@ fn main() -> Result<(), ExitFailure> {
                 aliases: file_config.aliases,
                 general: file_config.general,
                 names: !no_names,
+                no_dupes: no_dupes,
             }
         }
         None => swaywsr::Options {
@@ -60,6 +67,7 @@ fn main() -> Result<(), ExitFailure> {
             aliases: swaywsr::config::EMPTY_MAP.clone(),
             general: swaywsr::config::EMPTY_MAP.clone(),
             names: !no_names,
+            no_dupes: no_dupes,
         },
     };
 


### PR DESCRIPTION
This adds a new option that only shows one icon per class regardless of how many of that class are opened. For example, I could have multiple Firefox windows open in a workspace but `swaywsr` will now only show one Firefox icon.

Had to slightly refactor the code in order to add in this functionality.