### PR TITLE
Fix clippy lints and a compiler warning

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,8 @@ lazy_static! {
     pub static ref EMPTY_OPT_MAP: Map<String, bool> = Map::new();
 }
 
-#[serde(default)]
 #[derive(Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub icons: Map<String, char>,
     pub aliases: Map<String, String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ fn get_class(node: &Node, config: &Config) -> Result<String, LookupError> {
             None => &class,
         };
 
-        let no_names = get_option(&config, "no_names");
+        let no_names = get_option(config, "no_names");
 
         Ok(match config.icons.get(&class) {
             Some(icon) => {
@@ -88,13 +88,13 @@ fn get_class(node: &Node, config: &Config) -> Result<String, LookupError> {
             None => match config.general.get("default_icon") {
                 Some(default_icon) => {
                     if no_names {
-                        format!("{}", default_icon)
+                        default_icon.to_string()
                     } else {
                         format!("{} {}", default_icon, class_display_name)
                     }
                 }
                 None => {
-                    format!("{}", class_display_name)
+                    class_display_name.to_string()
                 }
             },
         })
@@ -125,9 +125,9 @@ fn get_window_nodes(mut nodes: Vec<Vec<&Node>>) -> Vec<&Node> {
     while let Some(next) = nodes.pop() {
         for n in next {
             nodes.push(n.nodes.iter().collect());
-            if let Some(_) = n.window {
+            if n.window.is_some() {
                 window_nodes.push(n);
-            } else if let Some(_) = n.app_id {
+            } else if n.app_id.is_some() {
                 window_nodes.push(n);
             }
         }
@@ -170,7 +170,7 @@ pub fn update_tree(connection: &mut Connection, config: &Config) -> Result<(), E
         };
 
         let classes = get_classes(&workspace, config);
-        let classes = if get_option(&config, "remove_duplicates") {
+        let classes = if get_option(config, "remove_duplicates") {
             classes.into_iter().unique().collect()
         } else {
             classes

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), ExitFailure> {
                 icons: file_config
                     .icons
                     .into_iter()
-                    .chain(swaywsr::icons::get_icons(&icons))
+                    .chain(swaywsr::icons::get_icons(icons))
                     .collect(),
                 aliases: file_config.aliases,
                 general: file_config.general,
@@ -65,7 +65,7 @@ fn main() -> Result<(), ExitFailure> {
             }
         }
         None => swaywsr::Config {
-            icons: swaywsr::icons::get_icons(&icons),
+            icons: swaywsr::icons::get_icons(icons),
             aliases: swaywsr::config::EMPTY_MAP.clone(),
             general: swaywsr::config::EMPTY_MAP.clone(),
             options: swaywsr::config::EMPTY_OPT_MAP.clone(),


### PR DESCRIPTION
Clippy lints fixed automatically using `cargo +nightly clippy --fix -Z unstable-options`

Compiler warning was:
```
Compiling swaywsr v1.1.1
warning: derive helper attribute is used before it is introduced
  --> src/config.rs:12:3
   |
12 | #[serde(default)]
   |   ^^^^^
13 | #[derive(Deserialize)]
   |          ----------- the attribute is introduced here
   |
   = note: `#[warn(legacy_derive_helpers)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
```