### PR TITLE
config: support XDG_CONFIG_HOME by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::collections::HashMap as Map;
 use std::fs::File;
 use std::io::Read;
+use std::path::{Path, PathBuf};
 
 lazy_static! {
     pub static ref EMPTY_MAP: Map<String, String> = Map::new();
@@ -29,10 +30,19 @@ impl Default for Config {
     }
 }
 
-pub fn read_toml_config(filename: &str) -> Result<Config, Error> {
-    let mut file = File::open(filename)?;
+pub fn read_toml_config(path: &Path) -> Result<Config, Error> {
+    let mut file = File::open(&path)?;
     let mut buffer = String::new();
     file.read_to_string(&mut buffer)?;
     let config: Config = toml::from_str(&buffer)?;
     Ok(config)
+}
+
+pub fn xdg_config_home() -> PathBuf {
+    // In the unlikely event that $HOME is not set, it doesn't really matter
+    // what we fall back on, so use /.config.
+    PathBuf::from(std::env::var("XDG_CONFIG_HOME").unwrap_or(format!(
+        "{}/.config",
+        std::env::var("HOME").unwrap_or_default()
+    )))
 }


### PR DESCRIPTION
For #8

Note that a config file is now required to exist either at `XDG_CONFIG_HOME` or at the location specified with `--config` since it didn't make sense to me to run swaywsr with no config.