### PR TITLE
Allow i3wsr compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ fn get_class(node: &Node, config: &Config) -> Result<String, LookupError> {
             None => &class,
         };
 
-        let no_names = get_option(config, "no-names");
+        let no_names = get_option(config, "no-names") || get_option(config, "no_names");
 
         Ok(match config.icons.get(&class) {
             Some(icon) => {
@@ -144,7 +144,7 @@ pub fn update_tree(connection: &mut Connection, config: &Config) -> anyhow::Resu
         };
 
         let classes = get_classes(&workspace, config);
-        let classes = if get_option(config, "remove-duplicates") {
+        let classes = if get_option(config, "remove-duplicates") || get_option(config, "remove_duplicates") {
             classes.into_iter().unique().collect()
         } else {
             classes


### PR DESCRIPTION
Moving from i3wsr to swaywsr, two options syntax in the toml configuration file have changed.

Allow to use the same syntax on i3wsr for those options so that near zero changes have to be made to switch to swaywsr in the config file.

Do not hesitate to tell me if you also want me to update the documentation.