### PR TITLE
Fix issue #13 MissingInformation class error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,9 @@ fn get_window_nodes(mut nodes: Vec<Vec<&Node>>) -> Vec<&Node> {
     while let Some(next) = nodes.pop() {
         for n in next {
             nodes.push(n.nodes.iter().collect());
-            window_nodes.push(n);
+            if NodeType::Con == n.node_type && n.name.is_some() {
+                window_nodes.push(n);
+            }
         }
     }
 


### PR DESCRIPTION
On sway, each workspace has a non-floating pseudo root container which hold all the other containers. This container is pretty basic and does not have any name.

When looking for window name, we loop through those containers and add them in the vector of valid windows. Later in the code, we retrieve the name of all the windows in the vector, and fall in the caveat of those empty-named containers.

Add a workaround not to add the 'non-floating' root containers.