### PR TITLE
Automate dependencies update through Github's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Sets automatic dependencies update
+version: 2
+updates:
+  # Maintain dependencies for Cargo
+  - package-ecosystem: "cargo"
+    # Workflow files stored in the default location of `.github/workflows`.
+    # (You don't need to specify `/.github/workflows` for `directory`. You can
+    # use `directory: "/"`.)
+    directory: "/"
+    # Set a monthly update so it does not drag too much attention ;)
+    # And set the update during the end of a week
+    schedule:
+      interval: "monthly"
+      day: "sunday"
+      time: "16:00"
+      timezone: "CET"
+    # Set a clear commit subject.
+    commit-message:
+      prefix: "[dependencies] "
+      include: "scope"
+    # Set assignees
+    assignees:
+      - "GallaisPoutine"
+
+


### PR DESCRIPTION
Hi @pedroscaff,

This aims to automate and help you maintaining this project updated with Rust crates and dependencies.

The automated update is enabled when going to the settings of your project, then under the Security related options, you have "Code security and analysis". This is where you can enable the "Dependabot version updates". You can also check for update in the "Insights", under "Dependency graph", which will show if there is an update to do.

The dependabot.yml is set to check for update once every month, the first sunday of the month and send a Pull Request on the master branch. I think this is a great granularity so you are not annoyed with too much notifications.

I also took the liberty to add myself as assignee for the pull request, this is only to keep me updated when there is ... well an update. :)

If you are uncomfortable with enabling those options on your project for whatever reason, then I don't mind. I only hope this will ease your work with this project. :)

Edit :

If you want full documentation about how this work then read [this](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates) and [this](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).

